### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -18,6 +18,10 @@
 
 name: "Microsoft Defender For Devops"
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/stitchmentalhealth626/zac/security/code-scanning/1](https://github.com/stitchmentalhealth626/zac/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the steps in the workflow:
- `contents: read` is needed for `actions/checkout` to read the repository contents.
- `security-events: write` is required for `github/codeql-action/upload-sarif` to upload SARIF results to the Security tab.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
